### PR TITLE
Downgrade fetch to v0.11 for IE9 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import 'airbnb-browser-shims';
  - [raf](https://www.npmjs.com/package/raf) - requestAnimationFrame polyfill for browsers and node
  - [requestIdleCallback](https://www.npmjs.com/package/ric-shim)
  - [matchmedia-polyfill](https://github.com/paulirish/matchMedia.js/) - window.matchMedia polyfill (only in browsers)
- - [whatwg-fetch](https://github.com/github/fetch) - fetch polyfill (only in browsers)
+ - [whatwg-fetch](https://github.com/github/fetch) - fetch polyfill (only in browsers, supports IE9+)
 
 ## Only browser shims
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "raf": "^3.3.0",
     "ric-shim": "^1.0.0",
     "webrtc-adapter": "^2.1.0",
-    "whatwg-fetch": "^2.0.2"
+    "whatwg-fetch": "^0.11"
   },
   "devDependencies": {
     "eslint": "^3.15.0",


### PR DESCRIPTION
## Overview
Need to downgrade `whatwg-fetch` to v0.11 for the full IE9 compatibility. No flashy new fetch polyfill for now.

