### PR TITLE
Bump the webrtc-adapter dependency to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "raf": "^3.3.2",
     "ric-shim": "^1.0.0",
     "smoothscroll-polyfill": "^0.3.5",
-    "webrtc-adapter": "^2.1.0",
+    "webrtc-adapter": "^2.1.0 || ^3 || ^4 || ^5",
     "whatwg-fetch": "^0.11"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Description
Safari 11 is landing on desktop and iOS11 soon! Bumping to the latest `webrtc-adapter` will make it so that we can use `MediaStream`s bug-free, among other things.

#### Testing
I tested this on the account verification flow locally for airbnb.com with all major versions since `2.1.0`.

---

@ljharb 