### PR TITLE
Remove webrtc-adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 =================
+  * [Breaking] Remove `webrtc-adapter`
 
 1.12.0 / 2017-09-14
 =================

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ import 'airbnb-browser-shims';
  - JS language shims from [airbnb-js-shims](https://github.com/airbnb/js-shims)
  - [ima-babel6-polyfill](https://www.npmjs.com/package/ima-babel6-polyfill) - fixes Babel 6 bugs with `super` calls in IE 9 and 10
  - [document.contains](https://developer.mozilla.org/en/docs/Web/API/Node/contains)
- - [webrtc-adapter](https://www.npmjs.com/package/webrtc-adapter) - A shim to insulate apps from WebRTC spec changes and browser prefix differences
  - [classlist-polyfill](https://www.npmjs.com/package/classlist-polyfill) - Element.prototype.classList polyfill (only in browsers)
  - [raf](https://www.npmjs.com/package/raf) - requestAnimationFrame polyfill for browsers and node
  - [requestIdleCallback](https://www.npmjs.com/package/ric-shim)

--- a/browser-only.js
+++ b/browser-only.js
@@ -11,8 +11,6 @@ require('./document-contains');
 // console.* polyfill for old browsers
 require('console-polyfill');
 
-require('webrtc-adapter');
-
 require('whatwg-fetch');
 
 if (typeof window !== 'undefined') {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "raf": "^3.3.2",
     "ric-shim": "^1.0.0",
     "smoothscroll-polyfill": "^0.3.6",
-    "webrtc-adapter": "^2.1.0 || ^3 || ^4 || ^5",
     "whatwg-fetch": "^0.11.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I am working to reduce the amount of JavaScript that we ship on most
pages of airbnb.com. One package that I noticed was rather large and
shipped on every page in a way that runs before all of the application
code is the webrtc-adapter package. This is a shim to insulate apps from
spec changes and prefix differences. However, we don't use WebRTC on
most of our pages, so I am moving it out of our browser shims package
and into the specific places that need it.

This is a breaking change.

@airbnb/webinfra 