### PR TITLE
[New] Add :focus-visible shim

### DIFF
--- a/browser-only.js
+++ b/browser-only.js
@@ -39,6 +39,9 @@ if (typeof window !== 'undefined') {
   require('shim-keyboard-event-key');
 }
 
+// :focus-visible shim
+require('focus-visible');
+
 require('raf/polyfill');
 
 global.requestIdleCallback = require('ric-shim');

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "console-polyfill": "^0.3.0",
     "document.contains": "^1.0.0",
     "element-closest": "^2.0.2",
+    "focus-visible": "^5.0.2",
     "ima-babel6-polyfill": "^0.12.0",
     "input-placeholder-polyfill": "^1.0.0",
     "intersection-observer": "^0.5.1",


### PR DESCRIPTION
Add `:focus-visible` shim, for keyboard-only focus styles.

- https://github.com/WICG/focus-visible
- https://css-tricks.com/keyboard-only-focus-styles/
- https://caniuse.com/#feat=css-focus-visible

Thank you, @calinoracation for pointing me to this magic!

Reviewers: @lencioni @calinoracation